### PR TITLE
use latest chroma to replace euclidean-distance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var distance = require('euclidean-distance')
 var chroma = require('chroma-js')
 var color
 var key
@@ -22,7 +21,7 @@ var namer = module.exports = function(color) {
   for (key in lists) {
     results[key] = lists[key]
       .map (function(name) {
-        name.distance = distance(color.lab(), chroma(name.hex).lab())
+        name.distance = chroma.distance(color, chroma(name.hex))
         return name
       })
       .sort (function(a, b) {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "mocha": "~1.13.0"
   },
   "dependencies": {
-    "chroma-js": "~0.5.2",
-    "euclidean-distance": "~0.1.0",
-    "require-dir": "^0.3.0"
+    "chroma-js": "^1.3.4"
   }
 }


### PR DESCRIPTION
I found out the lastest chroma integrates euclidean-distance function, so we can just use it.
And I also remove the unused dependency `require-dir`.

All tests are complete.