### PR TITLE
add: options `pick` and `omit` with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ name("rgb(255,0,0)")
 name("rgba(255,0,0,1)")
 ```
 
+## Options
+
+### options.pick
+This option allows us to derive names from the dedicated lists for faster computation.
+
+```js
+var names = namer(color, { pick: ['basic', 'x11'] })
+// output: { basic: [...], x11: [...] }
+```
+
+### options.omit
+The opposite of `options.pick`.
+
+```js
+var names = namer(color, { omit: ['pantone', 'roygbiv'] })
+// output: { basic: [...], html: [...], x11: [...], ntc: [...] }
+```
+
 ## Tests
 
 ```

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 
 var distance = require('euclidean-distance')
 var chroma = require('chroma-js')
-var color
-var key
 
 // These `require` statements are all explicit
 // to keep the browserify build from breaking
@@ -16,10 +14,18 @@ var lists = {
   x11: require('./lib/colors/x11')
 }
 
-var namer = module.exports = function(color) {
+var namer = module.exports = function(color, options) {
+  options = options || {}
+
   color = chroma(color)
   var results = {}
-  for (key in lists) {
+  for (var key in lists) {
+    if (options.pick && options.pick.indexOf(key) === -1) {
+      continue
+    }
+    if (options.omit && options.omit.indexOf(key) !== -1) {
+      continue
+    }
     results[key] = lists[key]
       .map (function(name) {
         name.distance = distance(color.lab(), chroma(name.hex).lab())

--- a/test/index.js
+++ b/test/index.js
@@ -66,4 +66,30 @@ suite('namer', function () {
 
   })
 
+  suite('options', function() {
+
+    test('can receive an empty object', function() {
+      var names = namer("hsl(50,100%,50%)", {})
+      assert.equal(names.basic[0].name, 'gold')
+    })
+
+    test('can receive `pick` option', function() {
+      var names = namer("hsl(50,100%,50%)", { pick: ['basic', 'pantone'] })
+      assert(Array.isArray(names.basic))
+      assert(Array.isArray(names.pantone))
+      assert.equal(Object.keys(names).length, 2)
+      assert.equal(names.html, undefined)
+      assert.equal(names.roygbiv, undefined)
+    })
+
+    test('can receive `omit` option', function() {
+      var names = namer("hsl(50,100%,50%)", { omit: ['basic', 'pantone'] })
+      assert(Array.isArray(names.html))
+      assert(Array.isArray(names.roygbiv))
+      assert.equal(Object.keys(names).length, Object.keys(namer.lists).length - 2)
+      assert.equal(names.basic, undefined)
+      assert.equal(names.pantone, undefined)
+    })
+  })
+
 })


### PR DESCRIPTION
I add these two options for flexibility, which allow people choose any name lists they want.
The tests and documentation are written.