### PR TITLE
adds color-name-list

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32,18 +32,16 @@ function update() {
 
   // Toggle input placeholder color
   $("#query").toggleClass("white", color.luminance() < 0.5)
-
   // Find color names
-  var colors = colorNamer(color.hex(), 'ntc')
-
+  var colors = colorNamer(color.hex(), {keep: 'colornamelist'})
+  console.log(colors)
   // Refresh list
-  colors.forEach(function(c) {
+  colors.colornamelist.forEach(function(c) {
     $("#colors").append(ich.color(c))
   })
 }
 
 $(function(){
-  $("#query").on('keyup', update)
   $("#query").on('change', update)
 
   $("form").on('submit', function(e) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ var lists = {
   ntc: require('./lib/colors/ntc'),
   pantone: require('./lib/colors/pantone'),
   roygbiv: require('./lib/colors/roygbiv'),
-  x11: require('./lib/colors/x11')
+  x11: require('./lib/colors/x11'),
+  colornamelist: require('color-name-list')
 }
 
 var namer = module.exports = function(color, options) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "~1.13.0"
   },
   "dependencies": {
-    "chroma-js": "^1.3.4"
+    "chroma-js": "^1.3.4",
+    "color-name-list": "^3.2.2"
   }
 }


### PR DESCRIPTION
So by adding color-name-list (~16k entries) that this was way to slow.

Would be awesome to preload a list for example something like require('color-namer').load(require('color-name-list'))

What do you think?

Used https://github.com/dtao/nearest-color until now, makes it blazing fast but visually less accurate. (Does not matter that much with that many entries anyway: https://codepen.io/meodai/pen/mEvZRx?editors=0110) click the brush